### PR TITLE
Adding option for mosaic variant calling files for DragenGE pipelines

### DIFF
--- a/dragen_post_cron.sh
+++ b/dragen_post_cron.sh
@@ -68,7 +68,7 @@ for path in $(find $dragen_results_dir -maxdepth 3 -mindepth 3 -type f -name "dr
      --sv_vcf ../"$runid".sv\{.vcf.gz,.vcf.gz.tbi\} \
      --cnv_vcf ../"$runid".cnv\{.vcf.gz,.vcf.gz.tbi\} \
      --bams_crams ../\*/\*\{.cram,.cram.crai\} \
-     --mosaic_vcf ../\*/Mosaic_Calling/\*.hard-filtered.vcf.gz
+     --mosaic_vcf ../\*/Mosaic_Calling/\*.hard-filtered.vcf.gz \
      --publish_dir results \
      --sequencing_run "$runid" \
      -with-dag "$runid".png \

--- a/dragen_post_cron.sh
+++ b/dragen_post_cron.sh
@@ -68,6 +68,7 @@ for path in $(find $dragen_results_dir -maxdepth 3 -mindepth 3 -type f -name "dr
      --sv_vcf ../"$runid".sv\{.vcf.gz,.vcf.gz.tbi\} \
      --cnv_vcf ../"$runid".cnv\{.vcf.gz,.vcf.gz.tbi\} \
      --bams_crams ../\*/\*\{.cram,.cram.crai\} \
+     --mosaic_vcf ../\*/Mosaic_Calling/\*.hard-filtered.vcf.gz
      --publish_dir results \
      --sequencing_run "$runid" \
      -with-dag "$runid".png \


### PR DESCRIPTION
- Adding variables to the dragen cron job to allow mosaic variants to be passed to the dragenge_post_processing pipeline. See pull requests in DragenGE (https://github.com/AWGL/DragenGE/pull/6) and dragenge_post_processing (https://github.com/AWGL/dragenge_post_processing/pull/10). 