### PR TITLE
Changing TSO500 to have subdirectory

### DIFF
--- a/pipeline_cron.sh
+++ b/pipeline_cron.sh
@@ -71,7 +71,7 @@ function processJobs {
                      elif [ $is_tso500 -gt 0 ]; then
 
                          echo "Keyword TSO500 found in SampleSheet so executing TSO500 solid pipeline"
-                         ssh ch1 "mkdir /Output/results/$run && cd /Output/results/$run && cp /data/diagnostics/pipelines/TSO500/TSO500_post_processing-master/*_TSO500.sh . && sbatch --export=raw_data=$path 1_TSO500.sh"
+                         ssh ch1 "mkdir /Output/results/$run && mkdir /Output/results/$run/TSO500 && cd /Output/results/$run/TSO500 && cp /data/diagnostics/pipelines/TSO500/TSO500_post_processing-master/*_TSO500.sh . && sbatch --export=raw_data=$path 1_TSO500.sh"
 
                      elif [ $is_ctdna -gt 0 ]; then
 


### PR DESCRIPTION
As per commit, updating TSO500 path to now be /Output/results/$run/TSO500. Will need to be timed with push of new TSO500 DNA pipeline. 