### PR TITLE
updated pipeline cron for win10 miseq samplesheets

### DIFF
--- a/pipeline_cron.sh
+++ b/pipeline_cron.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -euo pipefail
 
+module load anaconda
+
 # Description: shell script to launch bioinformatics analysis pipelines.
 # This script should be executed as sbsuser 
 # Date: 18/08/20
@@ -52,7 +54,26 @@ function processJobs {
 
 
                     if [ "$instrumentType" == "miseq" ]; then
+                        
+                        ### For now we only want to change the sample sheets back on Nemo - remove this loop and just keep commands when Dory is updated
+                        if [[ $run =~ [0-9]{6}[_][M][0][0][7][6][6][_] ]]; then
+                            echo "Run on Nemo - fix samplesheet."
 
+                            ### Copy the Illumina Samplesheet
+                            mv $raw_write/$instrumentType/$run/SampleSheet.csv $raw_write/$instrumentType/$run/SampleSheet_orig.csv
+
+                            ### Convert from Windows file back to csv
+                            conda activate dos2unix
+                            dos2unix --newfile $raw_write/$instrumentType/$run/SampleSheet_orig.csv $raw_write/$instrumentType/$run/SampleSheet.csv # on wren
+                            conda deactivate
+
+                            ### Add commas to blank lines
+                            sed -i "s/^[[:blank:]]*$/,,,,,,,,/" $raw_write/$instrumentType/$run/SampleSheet.csv
+
+                        else
+                            echo "Run on Dory - do not change samplesheet."
+
+                        fi
 
                         cat $raw_write/$instrumentType/$run/SampleSheet.csv | sed 's/Name$ge/pipelineName=germline_enrichment_nextflow;pipelineVersion=master/' | sed 's/Name$SA/pipelineName=SomaticAmplicon;pipelineVersion=master/' | sed 's/NGHS101X/NGHS-101X/' | sed 's/NGHS102X/NGHS-102X/' | sed 's/ref\$/referral=/' | sed 's/%/;/g' | sed 's/\$/=/g' > $raw_write/$instrumentType/$run/SampleSheet_fixed.csv
 


### PR DESCRIPTION
Updated pipeline cron for the new Windows10 MiSeq sample sheets. Fixes #3.

Script now:
1. Checks if the run was on Nemo (contains M00766) or Dory
If on Nemo
2. Makes a copy of the Illumina edited sample sheet
3. Converts back to Linux line endings with dos2unix
4. Adds commas to blank lines so they can be parsed by AutoQC

Additional commas have not been added to the other lines as they are not needed. Description fields have been reordered by Illumina but this does not effect AutoQC or MakeVariableFiles. Downstream pipelines don't use the samplesheet, only the variables files.

Before deployment, the wren account that runs pipeline_cron.sh needs a new conda environment for dos2unix
`conda create --name dos2unix`
`conda install -c conda-forge dos2unix`

Once Dory has been updated, we can remove the if/else lines.

Test data on hard drive with sticker in `naomi/miseq_samplesheet_fix/archive/230817_M00766_0557_000000000-L463T/`

Have tested:
- AutoQC sample_sheet_parser.py function works as expected
- Run with new samplesheet successfully upload to AutoQC
- MakeVariableFiles still works with new samplesheet - no differences between variables files for 230817_M00766_0557_000000000-L463T from live files

Commands for testing outside of the cron:
```
#!/bin/bash

basedir="/media/na282549/D621-FA1E/naomi/miseq_samplesheet_fix/archive/230817_M00766_0557_000000000-L463T/" # test data

nemo="230817_M00766_0557_000000000-L463T"
dory="230817_M02641_0562_000000000-KYMLB"

run=$nemo

### For now we only want to change the sample sheets back on Nemo - remove this loop and just keep commands when Dory is updated
if [[ $run =~ [0-9]{6}[_][M][0][0][7][6][6][_] ]]; then
    echo "Run on Nemo - continue."

    ### Copy the Illumina Samplesheet
    cp ${basedir}SampleSheet.csv ${basedir}SampleSheet_orig.csv
    #mv $raw_write/$instrumentType/$run/SampleSheet.csv $raw_write/$instrumentType/$run/SampleSheet_orig.csv  # on wren

    ### Convert from Windows file back to csv
    dos2unix --newfile ${basedir}SampleSheet_orig.csv ${basedir}SampleSheet.csv
    #dos2unix --newfile $raw_write/$instrumentType/$run/SampleSheet_orig.csv $raw_write/$instrumentType/$run/SampleSheet.csv # on wren

    ### Add commas to blank lines
    sed -i "s/^[[:blank:]]*$/,,,,,,,,/" ${basedir}SampleSheet.csv
    #sed -i "s/^[[:blank:]]*$/,,,,,,,,/" $raw_write/$instrumentType/$run/SampleSheet.csv # on wren

else
    echo "Run on Dory - do not change samplesheet."

fi
```
