### PR TITLE
ctDNA master to main Closes #24

### DIFF
--- a/pipeline_cron.sh
+++ b/pipeline_cron.sh
@@ -54,7 +54,7 @@ function processJobs {
                     mv $raw_write/$instrumentType/$run/RTAComplete.txt $raw_write/$instrumentType/$run/_RTAComplete.txt
 
                     #allow time for changes to copy from data_heath to data
-                    sleep 5m
+                    sleep 20m
 
                     # counting instances of Dragen in SampleSheet
                     set +e


### PR DESCRIPTION
Master to main for ctDNA. Closes #24. 

Also increased sleep on cron to 20 minutes to allow more time for sync. May help with recent issues with TSO500. 